### PR TITLE
Created a handleLogout function and adjusted renderScreen

### DIFF
--- a/App.js
+++ b/App.js
@@ -81,11 +81,11 @@ export default function App() {
   const renderScreen = () => {
     switch (appState) {
       case "login":
-        return LoginScreen();
-        //return <LoginScreen setAppState={setAppState} />;
+        //return LoginScreen();
+        return <LoginScreen setAppState={setAppState} />;
       case "home":
-        return HomeScreen();
-        //return <LoginScreen setAppState={setAppState} />;
+        //return HomeScreen();
+        return <HomeScreen setAppState={setAppState} />;
       case "record":
         return RecordScreen({
           route: currentRoute,
@@ -93,9 +93,11 @@ export default function App() {
           mapRef: mapRef,
         });
       case "personal":
-        return PersonalScreen();
+        //return PersonalScreen();
+        return <PersonalScreen setAppState={setAppState} />;
       case "settings":
-        return SettingsScreen();
+        //return SettingsScreen();
+        return <SettingsScreen setAppState={setAppState} />;
       default:
         return null;
     }

--- a/components/SettingsScreen.js
+++ b/components/SettingsScreen.js
@@ -11,6 +11,23 @@ export const SettingsScreen = () => {
     numberOfFriends: 10,
     totalActivity: 100,
   };
+
+
+  /**
+   * Handles the user logout when the button is pressed. 
+   * 
+   */
+  const handleLogout = () => {
+
+    console.log("User logged out");
+
+
+    if (setAppState) {
+      setAppState("login");
+    }
+  };
+
+
   return (
     <View style={styles.container}>
       <View style={styles.card}>


### PR DESCRIPTION
Closes #11 

I adjusted the renderScreen switch statements in App.js because the way it was set before, it was only a function call.
By changing it to "return <...Screen setAppState={setAppState} />;" it is still using it as a component in React and ensures that the component is properly integrated into React's ecosystem. 